### PR TITLE
Handle function payload too large error

### DIFF
--- a/app/api/submit/route.ts
+++ b/app/api/submit/route.ts
@@ -4,114 +4,45 @@ import { NextRequest, NextResponse } from 'next/server'
 import { submitToGoogleSheets } from '@/lib/google-sheets'
 import { formSchema } from '@/lib/validation'
 import { FormSubmission } from '@/lib/types'
-import { uploadImageToDrive } from '@/lib/google-drive'
-import { uploadImageToGCS } from '@/lib/google-cloud-storage'
 
 export async function POST(request: NextRequest) {
   try {
     const contentType = request.headers.get('content-type') || ''
-    let payload: any
-    let beforeUrl: string | null = null
-    let afterUrl: string | null = null
 
     if (contentType.includes('multipart/form-data')) {
-      const form = await request.formData()
-      const purchaseLocation = String(form.get('purchaseLocation') || '')
-      const npsScore = Number(form.get('npsScore') || 0)
-      const feedbackDetail = String(form.get('feedbackDetail') || '')
-      const skinConcern = String(form.get('skinConcern') || '')
-      const emailAddress = String(form.get('emailAddress') || '')
-
-      // Validate text fields
-      const validatedData = formSchema.parse({
-        purchaseLocation,
-        npsScore,
-        feedbackDetail,
-        skinConcern,
-        emailAddress,
-      })
-
-      // Optional image uploads to Drive/GCS
-      const folderId = process.env.GOOGLE_DRIVE_FOLDER_ID
-      const beforeFile = form.get('beforePhoto') as unknown as File | null
-      const afterFile = form.get('afterPhoto') as unknown as File | null
-
-      try {
-        const useGCS = process.env.USE_GCS === 'true'
-        const uploadBefore = async () => {
-          if (beforeFile && typeof beforeFile === 'object' && (beforeFile as any).arrayBuffer) {
-            if (useGCS) {
-              const bucket = process.env.GCS_BUCKET_NAME
-              if (!bucket) throw new Error('GCS_BUCKET_NAME is not set')
-              beforeUrl = await uploadImageToGCS({
-                file: beforeFile,
-                bucketName: bucket,
-                destination: `uploads/before_${Date.now()}.jpg`,
-              })
-            } else {
-              beforeUrl = await uploadImageToDrive({
-                file: beforeFile,
-                filename: `before_${Date.now()}.jpg`,
-                mimeType: (beforeFile as any).type || 'image/jpeg',
-                folderId,
-              })
-            }
-          }
-        }
-        const uploadAfter = async () => {
-          if (afterFile && typeof afterFile === 'object' && (afterFile as any).arrayBuffer) {
-            if (useGCS) {
-              const bucket = process.env.GCS_BUCKET_NAME
-              if (!bucket) throw new Error('GCS_BUCKET_NAME is not set')
-              afterUrl = await uploadImageToGCS({
-                file: afterFile,
-                bucketName: bucket,
-                destination: `uploads/after_${Date.now()}.jpg`,
-              })
-            } else {
-              afterUrl = await uploadImageToDrive({
-                file: afterFile,
-                filename: `after_${Date.now()}.jpg`,
-                mimeType: (afterFile as any).type || 'image/jpeg',
-                folderId,
-              })
-            }
-          }
-        }
-
-        // Run image uploads concurrently with an overall guard timeout
-        await Promise.race([
-          Promise.all([uploadBefore(), uploadAfter()]),
-          new Promise((_r, reject) => setTimeout(() => reject(new Error('Image upload timeout')), 10000)),
-        ])
-      } catch (e) {
-        console.warn('Image upload skipped or failed:', e)
-      }
-
-      payload = { ...validatedData }
-    } else {
-      const body = await request.json()
-      // Validate form data
-      const validatedData = formSchema.parse(body)
-      payload = validatedData
+      return NextResponse.json(
+        { success: false, message: 'Multipart uploads are no longer supported. Please update the client.' },
+        { status: 413 }
+      )
     }
-    
-    // Create submission object
+
+    const body = await request.json()
+
+    const validatedData = formSchema.parse({
+      purchaseLocation: String(body.purchaseLocation || ''),
+      npsScore: Number(body.npsScore || 0),
+      feedbackDetail: String(body.feedbackDetail || ''),
+      skinConcern: String(body.skinConcern || ''),
+      emailAddress: String(body.emailAddress || ''),
+    })
+
+    const beforeUrl: string | null = body.beforeUrl || null
+    const afterUrl: string | null = body.afterUrl || null
+
     const submission: FormSubmission = {
       timestamp: new Date().toISOString(),
-      purchaseLocation: payload.purchaseLocation,
-      npsScore: payload.npsScore,
-      feedbackDetail: payload.feedbackDetail,
-      skinConcern: payload.skinConcern,
-      emailAddress: payload.emailAddress,
-      joinedLoyalty: true, // Always true since they're submitting the form
+      purchaseLocation: validatedData.purchaseLocation,
+      npsScore: validatedData.npsScore,
+      feedbackDetail: validatedData.feedbackDetail,
+      skinConcern: validatedData.skinConcern,
+      emailAddress: validatedData.emailAddress,
+      joinedLoyalty: true,
       beforeUrl,
       afterUrl,
     }
-    
-    // Submit to Google Sheets
+
     await submitToGoogleSheets(submission)
-    
+
     return NextResponse.json({ 
       success: true, 
       message: 'Thank you for your feedback!' 
@@ -121,7 +52,6 @@ export async function POST(request: NextRequest) {
     console.error('Form submission error:', error)
     
     if (error instanceof Error) {
-      // Provide slightly clearer messages for common misconfigurations
       const msg = /Sheet ID not configured/i.test(error.message)
         ? 'Server is missing Google Sheet configuration.'
         : /invalid_grant|unauthorized|credentials/i.test(error.message)

--- a/app/api/upload-url/route.ts
+++ b/app/api/upload-url/route.ts
@@ -1,0 +1,83 @@
+export const runtime = 'nodejs'
+
+import { NextRequest, NextResponse } from 'next/server'
+import { Storage } from '@google-cloud/storage'
+
+function getExtensionFromFilename(filename?: string): string {
+  if (!filename) return ''
+  const idx = filename.lastIndexOf('.')
+  if (idx === -1) return ''
+  const ext = filename.slice(idx + 1).toLowerCase()
+  return ext ? `.${ext}` : ''
+}
+
+function encodeGcsPath(path: string): string {
+  return path
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/')
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json().catch(() => ({}))
+    const filename: string | undefined = body?.filename
+    const contentType: string | undefined = body?.contentType
+    const kind: string | undefined = body?.kind
+
+    if (!contentType) {
+      return NextResponse.json({ message: 'contentType is required' }, { status: 400 })
+    }
+
+    const bucketName = process.env.GCS_BUCKET_NAME
+    if (!bucketName) {
+      return NextResponse.json({ message: 'GCS_BUCKET_NAME is not set' }, { status: 500 })
+    }
+
+    const storage = new Storage({
+      credentials: {
+        client_email: process.env.GOOGLE_CLIENT_EMAIL,
+        private_key: process.env.GOOGLE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
+      },
+      projectId: process.env.GOOGLE_PROJECT_ID,
+    })
+
+    const bucket = storage.bucket(bucketName)
+    const [exists] = await bucket.exists()
+    if (!exists) {
+      return NextResponse.json({ message: `GCS bucket not found: ${bucketName}` }, { status: 500 })
+    }
+
+    const uniqueId = globalThis.crypto?.randomUUID?.() || Math.random().toString(36).slice(2, 10)
+    const suffix = getExtensionFromFilename(filename)
+    const base = kind && typeof kind === 'string' ? kind : 'image'
+    const destination = `uploads/${base}_${Date.now()}_${uniqueId}${suffix}`
+
+    const fileRef = bucket.file(destination)
+
+    const [uploadUrl] = await fileRef.getSignedUrl({
+      version: 'v4',
+      action: 'write',
+      expires: Date.now() + 10 * 60 * 1000, // 10 minutes
+      contentType,
+    })
+
+    let viewUrl: string
+    const bucketIsPublic = process.env.GCS_PUBLIC_READ === 'true'
+    if (bucketIsPublic) {
+      viewUrl = `https://storage.googleapis.com/${bucketName}/${encodeGcsPath(destination)}`
+    } else {
+      const [signedReadUrl] = await fileRef.getSignedUrl({
+        version: 'v4',
+        action: 'read',
+        expires: Date.now() + 7 * 24 * 60 * 60 * 1000, // 7 days
+      })
+      viewUrl = signedReadUrl
+    }
+
+    return NextResponse.json({ uploadUrl, viewUrl, objectPath: destination })
+  } catch (error) {
+    console.error('Signed URL error:', error)
+    return NextResponse.json({ message: 'Failed to generate upload URL' }, { status: 500 })
+  }
+}

--- a/app/form/page.tsx
+++ b/app/form/page.tsx
@@ -69,23 +69,52 @@ export default function FormPage() {
     }
   }
 
+  async function uploadViaSignedUrl(file: File, kind: 'before' | 'after'): Promise<string> {
+    const res = await fetch('/api/upload-url', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ filename: file.name, contentType: file.type || 'application/octet-stream', kind }),
+    })
+    if (!res.ok) throw new Error('Failed to get upload URL')
+    const { uploadUrl, viewUrl } = await res.json()
+
+    const putRes = await fetch(uploadUrl, {
+      method: 'PUT',
+      headers: { 'content-type': file.type || 'application/octet-stream' },
+      body: file,
+    })
+    if (!putRes.ok) throw new Error('Upload failed')
+
+    return viewUrl
+  }
+
   const onSubmit = async (data: FormSchema) => {
     setIsSubmitting(true)
     const controller = new AbortController()
-    const timeoutId = setTimeout(() => controller.abort(), 15000)
+    const timeoutId = setTimeout(() => controller.abort(), 20000)
     try {
-      const formData = new FormData()
-      formData.append('purchaseLocation', data.purchaseLocation)
-      formData.append('npsScore', String(data.npsScore))
-      formData.append('feedbackDetail', data.feedbackDetail)
-      formData.append('skinConcern', data.skinConcern)
-      formData.append('emailAddress', data.emailAddress)
-      if (beforePhoto) formData.append('beforePhoto', beforePhoto)
-      if (afterPhoto) formData.append('afterPhoto', afterPhoto)
+      let beforeUrl: string | undefined
+      let afterUrl: string | undefined
+
+      if (beforePhoto) {
+        beforeUrl = await uploadViaSignedUrl(beforePhoto, 'before')
+      }
+      if (afterPhoto) {
+        afterUrl = await uploadViaSignedUrl(afterPhoto, 'after')
+      }
 
       const response = await fetch('/api/submit', {
         method: 'POST',
-        body: formData,
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          purchaseLocation: data.purchaseLocation,
+          npsScore: data.npsScore,
+          feedbackDetail: data.feedbackDetail,
+          skinConcern: data.skinConcern,
+          emailAddress: data.emailAddress,
+          beforeUrl: beforeUrl || null,
+          afterUrl: afterUrl || null,
+        }),
         signal: controller.signal,
       })
 
@@ -103,9 +132,7 @@ export default function FormPage() {
             const text = await response.text()
             message = text?.slice(0, 300)
           }
-        } catch {
-          // fall through to default messages
-        }
+        } catch {}
 
         if (!message) {
           if (status === 413) message = 'Upload too large. Please use images under 4 MB each.'
@@ -118,7 +145,7 @@ export default function FormPage() {
       if (error?.name === 'AbortError') {
         alert('Request timed out. Please try again.')
       } else {
-        alert('Something went wrong. Please try again.')
+        alert(error?.message || 'Something went wrong. Please try again.')
       }
     } finally {
       clearTimeout(timeoutId)


### PR DESCRIPTION
Switch image uploads to client-direct GCS to resolve the "Request Entity Too Large" (FUNCTION_PAYLOAD_TOO_LARGE) error.

The previous implementation sent large image files through the serverless function, exceeding Vercel's 4.5 MB body limit. This change introduces a new endpoint to mint GCS signed URLs, allowing the client to upload images directly to Google Cloud Storage. The serverless function now only receives a small JSON payload containing the URLs of the uploaded images, bypassing the size constraint.

---
<a href="https://cursor.com/background-agent?bcId=bc-16a9287a-3b9d-4552-831a-f6342922c631">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-16a9287a-3b9d-4552-831a-f6342922c631">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

